### PR TITLE
Cross-platform build (tsc alternative)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ bower_components
 
 # Editors
 .idea
+.vscode
 *.iml
 
 # OS metadata

--- a/package.json
+++ b/package.json
@@ -5,10 +5,10 @@
   "main": "dist/src/index.js",
   "typings": "dist/src/index.d.ts",
   "scripts": {
-    "build": "npm run clean && tsc",
-    "clean": "rm -rf dist",
+    "build": "npm run clean && tsc --build",
+    "clean": "tsc --build --clean",
     "tsc": "tsc",
-    "test": "npm run tsc && jasmine --config=./spec/support/jasmine.json"
+    "test": "tsc --build && jasmine --config=./spec/support/jasmine.json"
   },
   "dependencies": {
     "js-yaml": "^4.0.0"


### PR DESCRIPTION
**What this PR does / why we need it**:
Provides cross-platform build possibility by using tsc clean capabilities instead of os specific command line.
Closes #60 
Alternative to #62 

**Special notes for reviewers**:

**Additional information (if needed):**