### PR TITLE
WIP support specification main branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@severlessworkflow/sdk-typescript",
   "version": "0.6.0",
+  "keywords": [
+    "SNAPSHOT"
+  ],
   "description": "Typescript SDK for Serverless Workflow Specification",
   "main": "umd/index.umd.min.js",
   "browser": "umd/index.umd.min.js",

--- a/tools/download-schemas.ts
+++ b/tools/download-schemas.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import {promises as fsPromises} from 'fs';
 import rimraf from 'rimraf';
 import yargs from 'yargs';
-import { version } from '../package.json';
+import { version, keywords} from '../package.json';
 const {writeFile,mkdir} = fsPromises;
 const rimrafP = async (f: string): Promise<void> => new Promise<void>((resolve, reject) => 
   rimraf(f, (err) => {
@@ -105,7 +105,7 @@ const downloadFile = async (url: string, dest: string): Promise<void> => mkdir(
 const downloadFiles = async (filesMap: Map<string, string>): Promise<void[]> => Promise.all(Array.from(filesMap).map(([dest, url]) => downloadFile(url, dest)));
 
 const argv = yargs(process.argv.slice(2)).argv;
-const ref = `v${version.split('.').slice(0,-1).join('.')}`;
+const ref = keywords.includes("SNAPSHOT") ? 'main' : `v${version.split('.').slice(0,-1).join('.')}`;
 /** The schema registry base url, either provided in args or based on the package version */
 const registryUrl: string = argv.registry as string || `https://api.github.com/repos/serverlessworkflow/specification/contents/schema?ref=${ref}`;
 console.log(`Using registry '${registryUrl}'`);


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:
Provide support to the specification main branch

**Special notes for reviewers**:

I understand that the sdk  has to evolve with the specification, so we should be able to generate the code from the main branch. 

_Should wee publish snapshot version to npmjs registry?_

the think is that npmjs does not allow overwrite packages (as maven does) so once one version is published there is no rollback. (I have already messed up things here.. ) 

Related found documentation 
- https://stackoverflow.com/questions/31156766/using-snapshot-in-private-npm-like-in-maven
- https://www.npmjs.com/package/npm-snapshot
- https://github.com/npm/cli/issues/1391 (closed with no response) 
- https://kevinkreuzer.medium.com/publishing-a-beta-or-alpha-version-to-npm-46035b630dd7

**Additional information (if needed):**