### PR TITLE
validate method return proprietary class

### DIFF
--- a/src/lib/validation-error.ts
+++ b/src/lib/validation-error.ts
@@ -1,9 +1,26 @@
-import { ErrorObject } from 'ajv';
+/*
+ * Copyright 2021-Present The Serverless Workflow Specification Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * oUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import { DefinedError } from 'ajv';
 
 export class ValidationError {
   readonly message: string;
-
-  constructor(readonly error: ErrorObject) {
+  
+  constructor(readonly error: DefinedError) {
     this.message = `invalid: ${error.instancePath} | ${error.schemaPath} | ${error.message}`;
   }
 }

--- a/src/lib/validation-error.ts
+++ b/src/lib/validation-error.ts
@@ -1,0 +1,3 @@
+export class ValidationError {
+  constructor(readonly message: string) {}
+}

--- a/src/lib/validation-error.ts
+++ b/src/lib/validation-error.ts
@@ -1,3 +1,9 @@
+import { ErrorObject } from 'ajv';
+
 export class ValidationError {
-  constructor(readonly message: string) {}
+  readonly message: string;
+
+  constructor(readonly error: ErrorObject) {
+    this.message = `invalid: ${error.instancePath} | ${error.schemaPath} | ${error.message}`;
+  }
 }

--- a/src/lib/workflow-validator.ts
+++ b/src/lib/workflow-validator.ts
@@ -15,15 +15,16 @@
  *
  */
 
-import { DefinedError, ValidateFunction } from 'ajv';
+import { ValidateFunction } from 'ajv';
 import { Specification } from './definitions';
 import { validators } from './validators';
 
 export class WorkflowValidator {
   /** The validation errors after running validate(), if any */
-  errors: DefinedError[] | never[] = [];
+  errors: ValidationError[] | never[] = [];
   /** The validate function */
   private validateFn: ValidateFunction<Specification.Workflow>;
+
   /**
    * Creates a new WorkflowValidator for the provided workflow
    * @param {Workflow} workflow The workflow to validate
@@ -31,13 +32,22 @@ export class WorkflowValidator {
   constructor(private workflow: Specification.Workflow) {
     this.validateFn = validators.get('Workflow') as ValidateFunction<Specification.Workflow>;
   }
+
   /**
    * Validates the workflow, populates the errors if any
    * @returns {boolean} If the workflow is valid or not
    */
   validate(): boolean {
     const isValid = this.validateFn(this.workflow);
-    this.errors = this.validateFn.errors as DefinedError[];
+    if (this.validateFn.errors) {
+      this.errors = this.validateFn.errors.map(
+        (error) => new ValidationError(`invalid: ${error.instancePath} | ${error.schemaPath} | ${error.message}`)
+      );
+    }
     return isValid;
   }
+}
+
+export class ValidationError {
+  constructor(readonly message: string) {}
 }

--- a/src/lib/workflow-validator.ts
+++ b/src/lib/workflow-validator.ts
@@ -18,36 +18,33 @@
 import { ValidateFunction } from 'ajv';
 import { Specification } from './definitions';
 import { validators } from './validators';
+import { ValidationError } from './validation-error';
 
 export class WorkflowValidator {
   /** The validation errors after running validate(), if any */
   errors: ValidationError[] | never[] = [];
-  /** The validate function */
-  private validateFn: ValidateFunction<Specification.Workflow>;
+
+  /** Whether the workflow is valid or not */
+  isValid: boolean;
 
   /**
    * Creates a new WorkflowValidator for the provided workflow
    * @param {Workflow} workflow The workflow to validate
    */
   constructor(private workflow: Specification.Workflow) {
-    this.validateFn = validators.get('Workflow') as ValidateFunction<Specification.Workflow>;
+    this.validate();
   }
 
   /**
    * Validates the workflow, populates the errors if any
-   * @returns {boolean} If the workflow is valid or not
    */
-  validate(): boolean {
-    const isValid = this.validateFn(this.workflow);
-    if (this.validateFn.errors) {
-      this.errors = this.validateFn.errors.map(
+  private validate(): void {
+    const validateFn = validators.get('Workflow') as ValidateFunction<Specification.Workflow>;
+    this.isValid = validateFn(this.workflow);
+    if (validateFn.errors) {
+      this.errors = validateFn.errors.map(
         (error) => new ValidationError(`invalid: ${error.instancePath} | ${error.schemaPath} | ${error.message}`)
       );
     }
-    return isValid;
   }
-}
-
-export class ValidationError {
-  constructor(readonly message: string) {}
 }

--- a/src/lib/workflow-validator.ts
+++ b/src/lib/workflow-validator.ts
@@ -15,7 +15,7 @@
  *
  */
 
-import { ValidateFunction } from 'ajv';
+import { ValidateFunction, DefinedError } from 'ajv';
 import { Specification } from './definitions';
 import { validators } from './validators';
 import { ValidationError } from './validation-error';
@@ -35,7 +35,7 @@ export class WorkflowValidator {
     const validateFn = validators.get('Workflow') as ValidateFunction<Specification.Workflow>;
     this.isValid = validateFn(this.workflow);
     if (validateFn.errors) {
-      this.errors = validateFn.errors.map((error) => new ValidationError(error));
+      this.errors = validateFn.errors.map((error) => new ValidationError(error as DefinedError));
     }
   }
 }

--- a/src/lib/workflow-validator.ts
+++ b/src/lib/workflow-validator.ts
@@ -22,29 +22,20 @@ import { ValidationError } from './validation-error';
 
 export class WorkflowValidator {
   /** The validation errors after running validate(), if any */
-  errors: ValidationError[] | never[] = [];
+  readonly errors: ValidationError[] | never[] = [];
 
   /** Whether the workflow is valid or not */
-  isValid: boolean;
+  readonly isValid: boolean;
 
   /**
    * Creates a new WorkflowValidator for the provided workflow
    * @param {Workflow} workflow The workflow to validate
    */
   constructor(private workflow: Specification.Workflow) {
-    this.validate();
-  }
-
-  /**
-   * Validates the workflow, populates the errors if any
-   */
-  private validate(): void {
     const validateFn = validators.get('Workflow') as ValidateFunction<Specification.Workflow>;
     this.isValid = validateFn(this.workflow);
     if (validateFn.errors) {
-      this.errors = validateFn.errors.map(
-        (error) => new ValidationError(`invalid: ${error.instancePath} | ${error.schemaPath} | ${error.message}`)
-      );
+      this.errors = validateFn.errors.map((error) => new ValidationError(error));
     }
   }
 }

--- a/src/serverless-workflow-sdk.ts
+++ b/src/serverless-workflow-sdk.ts
@@ -15,6 +15,7 @@
  *
  */
 
+export * from './lib/validation-error';
 export * from './lib/workflow-converter';
 export * from './lib/workflow-validator';
 export * from './lib/validators';

--- a/tests/workflow-validator.spec.ts
+++ b/tests/workflow-validator.spec.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2021-Present The Serverless Workflow Specification Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+import { ValidationError, WorkflowValidator } from '../src/';
+import { Workflow } from '../src/lib/definitions/workflow';
+
+describe('workflow-validator', () => {
+  it('should return errors instance of ValidationError if the workflow provided is not valid', () => {
+    // @ts-ignore
+    const workflow = {
+      id: 'helloworld',
+      name: 'Hello World Workflow',
+      version: '1.0',
+      description: 'Inject Hello World',
+      start: 'Hello State',
+      states: [],
+    } as Workflow;
+
+    const workflowValidator = new WorkflowValidator(workflow);
+    expect(workflowValidator.errors.length).toBe(0);
+
+    workflowValidator.validate();
+    expect(workflowValidator.errors.length).toBe(1);
+    expect(workflowValidator.errors[0].constructor === ValidationError).toBeTruthy(
+      'Expected errors to be instance of ValidationError'
+    );
+  });
+
+  it('should have no errors if the workflow is valid', () => {
+    const workflow = {
+      id: 'helloworld',
+      version: '1.0',
+      name: 'Hello World Workflow',
+      description: 'Inject Hello World',
+      start: 'Hello State',
+      states: [
+        {
+          name: 'Hello State',
+          type: 'inject',
+          data: {
+            result: 'Hello World!',
+          },
+          end: true,
+        },
+      ],
+    } as Workflow;
+    
+    const workflowValidator = new WorkflowValidator(workflow);
+    workflowValidator.validate();
+    expect(workflowValidator.errors.length).toBe(0);
+  });
+});

--- a/tests/workflow-validator.spec.ts
+++ b/tests/workflow-validator.spec.ts
@@ -35,6 +35,8 @@ describe('workflow-validator', () => {
     expect(workflowValidator.errors[0].constructor === ValidationError).toBeTruthy(
       'Expected errors to be instance of ValidationError'
     );
+    expect(workflowValidator.errors[0].message).toMatch("states");
+
   });
 
   it('should have no errors if the workflow is valid', () => {

--- a/tests/workflow-validator.spec.ts
+++ b/tests/workflow-validator.spec.ts
@@ -30,9 +30,7 @@ describe('workflow-validator', () => {
     } as Workflow;
 
     const workflowValidator = new WorkflowValidator(workflow);
-    expect(workflowValidator.errors.length).toBe(0);
-
-    workflowValidator.validate();
+    expect(workflowValidator.isValid).toBeFalsy('Expected isValid to be false');
     expect(workflowValidator.errors.length).toBe(1);
     expect(workflowValidator.errors[0].constructor === ValidationError).toBeTruthy(
       'Expected errors to be instance of ValidationError'
@@ -57,9 +55,9 @@ describe('workflow-validator', () => {
         },
       ],
     } as Workflow;
-    
+
     const workflowValidator = new WorkflowValidator(workflow);
-    workflowValidator.validate();
     expect(workflowValidator.errors.length).toBe(0);
+    expect(workflowValidator.isValid).toBeTruthy('Expected isValid to be true');
   });
 });


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:

`errors` property in `workflowValidation` class is defined as a list of `DefinedError` from `ajv` library, I think that this class should be replaced for a proprietary class, like `validationError` in this case

**Special notes for reviewers**:

**Additional information (if needed):**