### PR TITLE
ignore additionalProperties when are declared as function

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@severlessworkflow/sdk-typescript",
-  "version": "0.6.0",
+  "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@severlessworkflow/sdk-typescript",
-      "version": "0.6.0",
+      "version": "1.0.0",
       "license": "http://www.apache.org/licenses/LICENSE-2.0.txt",
       "dependencies": {
         "ajv": "^8.1.0",

--- a/src/lib/definitions/callbackstate.ts
+++ b/src/lib/definitions/callbackstate.ts
@@ -110,7 +110,7 @@ export class Callbackstate {
    * Normalize the value of each property by recursively deleting properties whose value is equal to its default value. Does not modify the object state.
    * @returns {Specification.Callbackstate} without deleted properties.
    */
-  normalize(): Callbackstate {
+  normalize = (): Callbackstate => {
     const clone = new Callbackstate(this);
 
     normalizeUsedForCompensationProperty(clone);
@@ -121,5 +121,5 @@ export class Callbackstate {
     setEndValueIfNoTransition(clone);
 
     return clone;
-  }
+  };
 }

--- a/src/lib/definitions/databasedswitch.ts
+++ b/src/lib/definitions/databasedswitch.ts
@@ -84,7 +84,7 @@ export class Databasedswitch {
    * Normalize the value of each property by recursively deleting properties whose value is equal to its default value. Does not modify the object state.
    * @returns {Specification.Databasedswitch} without deleted properties.
    */
-  normalize(): Databasedswitch {
+  normalize = (): Databasedswitch => {
     const clone = new Databasedswitch(this);
 
     normalizeUsedForCompensationProperty(clone);
@@ -92,5 +92,5 @@ export class Databasedswitch {
     normalizeDataConditionsProperty(clone);
 
     return clone;
-  }
+  };
 }

--- a/src/lib/definitions/defaultdef.ts
+++ b/src/lib/definitions/defaultdef.ts
@@ -39,7 +39,7 @@ export class Defaultdef /* Default definition. Can be either a transition or end
    * Normalize the value of each property by recursively deleting properties whose value is equal to its default value. Does not modify the object state.
    * @returns {Specification.Defaultdef} without deleted properties.
    */
-  normalize(): Defaultdef {
+  normalize = (): Defaultdef => {
     const clone = new Defaultdef(this);
 
     normalizeEndProperty(clone);
@@ -47,5 +47,5 @@ export class Defaultdef /* Default definition. Can be either a transition or end
     setEndValueIfNoTransition(clone);
 
     return clone;
-  }
+  };
 }

--- a/src/lib/definitions/delaystate.ts
+++ b/src/lib/definitions/delaystate.ts
@@ -93,7 +93,7 @@ export class Delaystate {
    * Normalize the value of each property by recursively deleting properties whose value is equal to its default value. Does not modify the object state.
    * @returns {Specification.Delaystate} without deleted properties.
    */
-  normalize(): Delaystate {
+  normalize = (): Delaystate => {
     const clone = new Delaystate(this);
 
     normalizeUsedForCompensationProperty(clone);
@@ -102,5 +102,5 @@ export class Delaystate {
     normalizeTransitionProperty(clone);
     setEndValueIfNoTransition(clone);
     return clone;
-  }
+  };
 }

--- a/src/lib/definitions/end.ts
+++ b/src/lib/definitions/end.ts
@@ -45,12 +45,12 @@ export class End {
    * Normalize the value of each property by recursively deleting properties whose value is equal to its default value. Does not modify the object state.
    * @returns {Specification.End} without deleted properties.
    */
-  normalize(): End {
+  normalize = (): End => {
     const clone = new End(this);
 
     normalizeCompensateProperty(clone);
     normalizeTerminateProperty(clone);
 
     return clone;
-  }
+  };
 }

--- a/src/lib/definitions/enddatacondition.ts
+++ b/src/lib/definitions/enddatacondition.ts
@@ -44,11 +44,11 @@ export class Enddatacondition {
    * Normalize the value of each property by recursively deleting properties whose value is equal to its default value. Does not modify the object state.
    * @returns {Specification.Enddatacondition} without deleted properties.
    */
-  normalize(): Enddatacondition {
+  normalize = (): Enddatacondition => {
     const clone = new Enddatacondition(this);
 
     normalizeEndProperty(clone);
 
     return clone;
-  }
+  };
 }

--- a/src/lib/definitions/enddeventcondition.ts
+++ b/src/lib/definitions/enddeventcondition.ts
@@ -56,11 +56,11 @@ export class Enddeventcondition {
    * Normalize the value of each property by recursively deleting properties whose value is equal to its default value. Does not modify the object state.
    * @returns {Specification.Enddeventcondition} without deleted properties.
    */
-  normalize(): Enddeventcondition {
+  normalize = (): Enddeventcondition => {
     const clone = new Enddeventcondition(this);
 
     normalizeEndProperty(clone);
 
     return clone;
-  }
+  };
 }

--- a/src/lib/definitions/error.ts
+++ b/src/lib/definitions/error.ts
@@ -51,7 +51,7 @@ export class Error {
    * Normalize the value of each property by recursively deleting properties whose value is equal to its default value. Does not modify the object state.
    * @returns {Specification.Error} without deleted properties.
    */
-  normalize(): Error {
+  normalize = (): Error => {
     const clone = new Error(this);
 
     normalizeEndProperty(clone);
@@ -60,5 +60,5 @@ export class Error {
     setEndValueIfNoTransition(clone);
 
     return clone;
-  }
+  };
 }

--- a/src/lib/definitions/eventbasedswitch.ts
+++ b/src/lib/definitions/eventbasedswitch.ts
@@ -91,7 +91,7 @@ export class Eventbasedswitch {
    * Normalize the value of each property by recursively deleting properties whose value is equal to its default value. Does not modify the object state.
    * @returns {Specification.Eventbasedswitch} without deleted properties.
    */
-  normalize(): Eventbasedswitch {
+  normalize = (): Eventbasedswitch => {
     const clone = new Eventbasedswitch(this);
 
     normalizeUsedForCompensationProperty(clone);
@@ -99,5 +99,5 @@ export class Eventbasedswitch {
     normalizeEventConditionsProperty(clone);
 
     return clone;
-  }
+  };
 }

--- a/src/lib/definitions/eventdef.ts
+++ b/src/lib/definitions/eventdef.ts
@@ -58,11 +58,11 @@ export class Eventdef {
    * Normalize the value of each property by recursively deleting properties whose value is equal to its default value. Does not modify the object state.
    * @returns {Specification.Eventdef} without deleted properties.
    */
-  normalize(): Eventdef {
+  normalize = (): Eventdef => {
     const clone = new Eventdef(this);
 
     normalizeKindProperty(clone);
 
     return clone;
-  }
+  };
 }

--- a/src/lib/definitions/eventstate.ts
+++ b/src/lib/definitions/eventstate.ts
@@ -89,7 +89,7 @@ export class Eventstate /* This state is used to wait for events from event sour
    * Normalize the value of each property by recursively deleting properties whose value is equal to its default value. Does not modify the object state.
    * @returns {Specification.Eventstate} without deleted properties.
    */
-  normalize(): Eventstate {
+  normalize = (): Eventstate => {
     const clone = new Eventstate(this);
 
     normalizeExclusiveProperty(clone);
@@ -100,5 +100,5 @@ export class Eventstate /* This state is used to wait for events from event sour
     setEndValueIfNoTransition(clone);
 
     return clone;
-  }
+  };
 }

--- a/src/lib/definitions/exectimeout.ts
+++ b/src/lib/definitions/exectimeout.ts
@@ -39,11 +39,11 @@ export class Exectimeout {
    * Normalize the value of each property by recursively deleting properties whose value is equal to its default value. Does not modify the object state.
    * @returns {Specification.Exectimeout} without deleted properties.
    */
-  normalize(): Exectimeout {
+  normalize = (): Exectimeout => {
     const clone = new Exectimeout(this);
 
     normalizeInterruptProperty(clone);
 
     return clone;
-  }
+  };
 }

--- a/src/lib/definitions/foreachstate.ts
+++ b/src/lib/definitions/foreachstate.ts
@@ -113,7 +113,7 @@ export class Foreachstate {
    * Normalize the value of each property by recursively deleting properties whose value is equal to its default value. Does not modify the object state.
    * @returns {Specification.Foreachstate} without deleted properties.
    */
-  normalize(): Foreachstate {
+  normalize = (): Foreachstate => {
     const clone = new Foreachstate(this);
 
     normalizeUsedForCompensationProperty(clone);
@@ -123,5 +123,5 @@ export class Foreachstate {
     setEndValueIfNoTransition(clone);
 
     return clone;
-  }
+  };
 }

--- a/src/lib/definitions/function.ts
+++ b/src/lib/definitions/function.ts
@@ -40,11 +40,12 @@ export class Function {
    * Normalize the value of each property by recursively deleting properties whose value is equal to its default value. Does not modify the object state.
    * @returns {Specification.Function} without deleted properties.
    */
-  normalize(): Function {
+
+  normalize = (): Function => {
     const clone = new Function(this);
 
     normalizeTypeRestProperty(clone);
 
     return clone;
-  }
+  };
 }

--- a/src/lib/definitions/injectstate.ts
+++ b/src/lib/definitions/injectstate.ts
@@ -84,7 +84,7 @@ export class Injectstate {
    * Normalize the value of each property by recursively deleting properties whose value is equal to its default value. Does not modify the object state.
    * @returns {Specification.Injectstate} without deleted properties.
    */
-  normalize(): Injectstate {
+  normalize = (): Injectstate => {
     const clone = new Injectstate(this);
 
     normalizeUsedForCompensationProperty(clone);
@@ -94,5 +94,5 @@ export class Injectstate {
     setEndValueIfNoTransition(clone);
 
     return clone;
-  }
+  };
 }

--- a/src/lib/definitions/onevents.ts
+++ b/src/lib/definitions/onevents.ts
@@ -48,11 +48,11 @@ export class Onevents {
    * Normalize the value of each property by recursively deleting properties whose value is equal to its default value. Does not modify the object state.
    * @returns {Specification.Onevents} without deleted properties.
    */
-  normalize(): Onevents {
+  normalize = (): Onevents => {
     const clone = new Onevents(this);
 
     normalizeActionModeParallelProperty(clone);
 
     return clone;
-  }
+  };
 }

--- a/src/lib/definitions/operationstate.ts
+++ b/src/lib/definitions/operationstate.ts
@@ -102,7 +102,7 @@ export class Operationstate {
    * Normalize the value of each property by recursively deleting properties whose value is equal to its default value. Does not modify the object state.
    * @returns {Specification.Operationstate} without deleted properties.
    */
-  normalize(): Operationstate {
+  normalize = (): Operationstate => {
     const clone = new Operationstate(this);
 
     normalizeActionModeSequentialProperty(clone);
@@ -113,5 +113,5 @@ export class Operationstate {
     setEndValueIfNoTransition(clone);
 
     return clone;
-  }
+  };
 }

--- a/src/lib/definitions/parallelstate.ts
+++ b/src/lib/definitions/parallelstate.ts
@@ -106,7 +106,7 @@ export class Parallelstate {
    * Normalize the value of each property by recursively deleting properties whose value is equal to its default value. Does not modify the object state.
    * @returns {Specification.Parallelstate} without deleted properties.
    */
-  normalize(): Parallelstate {
+  normalize = (): Parallelstate => {
     const clone = new Parallelstate(this);
 
     normalizeCompletionTypeProperty(clone);
@@ -118,5 +118,5 @@ export class Parallelstate {
     setEndValueIfNoTransition(clone);
 
     return clone;
-  }
+  };
 }

--- a/src/lib/definitions/repeat.ts
+++ b/src/lib/definitions/repeat.ts
@@ -51,12 +51,12 @@ export class Repeat {
    * Normalize the value of each property by recursively deleting properties whose value is equal to its default value. Does not modify the object state.
    * @returns {Specification.Repeat} without deleted properties.
    */
-  normalize(): Repeat {
+  normalize = (): Repeat => {
     const clone = new Repeat(this);
 
     normalizeContinueOnErrorProperty(clone);
     normalizeCheckBeforeProperty(clone);
 
     return clone;
-  }
+  };
 }

--- a/src/lib/definitions/subflowstate.ts
+++ b/src/lib/definitions/subflowstate.ts
@@ -105,7 +105,7 @@ export class Subflowstate {
    * Normalize the value of each property by recursively deleting properties whose value is equal to its default value. Does not modify the object state.
    * @returns {Specification.Subflowstate} without deleted properties.
    */
-  normalize(): Subflowstate {
+  normalize = (): Subflowstate => {
     const clone = new Subflowstate(this);
 
     normalizeUsedForCompensationProperty(clone);
@@ -120,5 +120,5 @@ export class Subflowstate {
     setEndValueIfNoTransition(clone);
 
     return clone;
-  }
+  };
 }

--- a/src/lib/definitions/transition.ts
+++ b/src/lib/definitions/transition.ts
@@ -44,11 +44,11 @@ export class Transition {
    * Normalize the value of each property by recursively deleting properties whose value is equal to its default value. Does not modify the object state.
    * @returns {Specification.Transition} without deleted properties.
    */
-  normalize(): Transition {
+  normalize = (): Transition => {
     const clone = new Transition(this);
 
     normalizeCompensateProperty(clone);
 
     return clone;
-  }
+  };
 }

--- a/src/lib/definitions/transitiondatacondition.ts
+++ b/src/lib/definitions/transitiondatacondition.ts
@@ -44,11 +44,11 @@ export class Transitiondatacondition {
    * Normalize the value of each property by recursively deleting properties whose value is equal to its default value. Does not modify the object state.
    * @returns {Specification.Transitiondatacondition} without deleted properties.
    */
-  normalize(): Transitiondatacondition {
+  normalize = (): Transitiondatacondition => {
     const clone = new Transitiondatacondition(this);
 
     normalizeTransitionProperty(clone);
 
     return clone;
-  }
+  };
 }

--- a/src/lib/definitions/transitioneventcondition.ts
+++ b/src/lib/definitions/transitioneventcondition.ts
@@ -55,11 +55,11 @@ export class Transitioneventcondition {
    * Normalize the value of each property by recursively deleting properties whose value is equal to its default value. Does not modify the object state.
    * @returns {Specification.Transitioneventcondition} without deleted properties.
    */
-  normalize(): Transitioneventcondition {
+  normalize = (): Transitioneventcondition => {
     const clone = new Transitioneventcondition(this);
 
     normalizeTransitionProperty(clone);
 
     return clone;
-  }
+  };
 }

--- a/src/lib/definitions/workflow.ts
+++ b/src/lib/definitions/workflow.ts
@@ -98,7 +98,7 @@ export class Workflow {
    * Normalize the value of each property by recursively deleting properties whose value is equal to its default value. Does not modify the object state.
    * @returns {Specification.Workflow} without deleted properties.
    */
-  normalize(): Workflow {
+  normalize = (): Workflow => {
     const clone = new Workflow(this);
     normalizeKeepActiveProperty(clone);
 
@@ -111,7 +111,7 @@ export class Workflow {
 
     normalizeExecTimeout(clone);
     return clone;
-  }
+  };
 
   /**
    * Parses the provided string as Workflow
@@ -144,6 +144,6 @@ export class Workflow {
    */
   static toYaml(workflow: Workflow): string {
     validate('Workflow', workflow);
-    return yaml.dump(workflow.normalize());
+    return yaml.dump(JSON.parse(JSON.stringify(workflow.normalize())));
   }
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -11,7 +11,7 @@ export const validate = (typeName: string, data: any): boolean => {
   const validateFn: ValidateFunction | undefined = validators.get(typeName);
   // TODO: ignore validation if no validator or throw ?
   if (!validateFn) return data;
-  if (!validateFn(data)) {
+  if (!validateFn(JSON.parse(JSON.stringify(data)))) {
     console.warn(validateFn.errors);
     const firstError: DefinedError = (validateFn.errors as DefinedError[])[0];
     throw new Error(

--- a/tests/lib/utils.spec.ts
+++ b/tests/lib/utils.spec.ts
@@ -8,4 +8,29 @@ describe('validate', () => {
   it('should return true for valid objects', () => {
     expect(validate('End', false)).toBeTruthy('Expected function validate to return true for valid objects');
   });
+
+  it('should ignore "normalize" function as additionalProperty', () => {
+    const functionObj = {
+      name: 'function',
+      operation: 'operation',
+      type: 'rest',
+      normalize: () => {
+        //do something
+      },
+    };
+
+    expect(validate('Function', functionObj)).toBeTruthy();
+  });
+  
+  it('should NOT ignore additionalProperties', () => {
+    const functionObj = {
+      name: 'function',
+      operation: 'operation',
+      type: 'rest',
+      keyAdditionalProperty: 'anyValue',
+    };
+    
+    expect(() => validate('Function', functionObj)).toThrowError(/keyAdditionalProperty/);
+  });
+
 });


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:

When I was testing the sdk into other project I realice that the behaviour of the binary (./dist/umd/index.umd.js) was different than the actual source code. The `validate` function was throwing an error related to have found  the "normalize" method as additional property

```
  {
    instancePath: '',
    schemaPath: '#/additionalProperties',
    keyword: 'additionalProperties',
    params: { additionalProperty: 'normalize' },
    message: 'must NOT have additional properties'
  }

```

I have changed the way we are deffinig "normalize" method to be able to reproduce the error in test.


**Special notes for reviewers**:
if you want to reproduce the error I've faced:

- in the sdk project (main branch): install the sdk in your npm: `npm run build && cd dist && npm link`
- in the project from where you want to test the sdk: install the sdk as a dependency `npm link @severlessworkflow/sdk-typescript` and create a workflow using builders, 

```

import {
	actionBuilder,
	databasedswitchBuilder,
	defaultdefBuilder,
	functionBuilder,
	functionrefBuilder,
	operationstateBuilder,
	Specification,
	subflowstateBuilder,
	transitiondataconditionBuilder,
	workflowBuilder,
} from '@severlessworkflow/sdk-typescript';


const workflow = workflowBuilder()
	.id('applicantrequest')
	.version('1.0')
	.name('Applicant Request Decision Workflow')
	.description('Determine if applicant request is valid')
	.start('CheckApplication')
	.functions([
		functionBuilder()
			.name('sendRejectionEmailFunction')
			.operation('http://myapis.org/applicationapi.json#emailRejection')
			.build(),
	])
	.states([
		databasedswitchBuilder()
			.name('CheckApplication')
			.dataConditions([
				transitiondataconditionBuilder()
					.condition('${ .applicants | .age >= 18 }')
					.transition('StartApplication')
					.build(),
				transitiondataconditionBuilder()
					.condition('${ .applicants | .age < 18 }')
					.transition('RejectApplication')
					.build(),
			])
			.default(defaultdefBuilder().transition('RejectApplication').build())
			.build(),
		subflowstateBuilder().name('StartApplication').workflowId('startApplicationWorkflowId').build(),
		operationstateBuilder()
			.name('RejectApplication')
			.actionMode('sequential')
			.actions([
				actionBuilder()
					.functionRef(
						functionrefBuilder()
							.refName('sendRejectionEmailFunction')
							.arguments({applicant: '${ .applicant }'})
							.build(),
					)
					.build(),
			])
			.build(),
	])
	.build();

console.log(Specification.Workflow.toYaml(workflow));


```

you will see an error like the following: 

```
  {
    instancePath: '/dataConditions/0',
    schemaPath: '#/additionalProperties',
    keyword: 'additionalProperties',
    params: { additionalProperty: 'normalize' },
    message: 'must NOT have additional properties'
  },

........                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    

Error: Databasedswitch is invalid: /dataConditions/0 | #/additionalProperties | must NOT have additional properties
      data: {
    "type": "switch",
    "usedForCompensation": false,
    "name": "CheckApplication",
    "dataConditions": [
        {
            "condition": "${ .applicants | .age >= 18 }",
            "transition": "StartApplication"
        },
        {
            "condition": "${ .applicants | .age < 18 }",
            "transition": "RejectApplication"
        }
    ],
    "default": {
        "transition": "RejectApplication"
    }
}

```

**Additional information (if needed):**