### PR TITLE
Fix auth properties instantiation

### DIFF
--- a/src/lib/definitions/utils.ts
+++ b/src/lib/definitions/utils.ts
@@ -263,15 +263,15 @@ export function overwriteProperties(object: { properties: string | Specification
     const properties: any = object.properties;
 
     if (properties.username && properties.password) {
-      object.properties = new Specification.Basicpropsdef(object);
+      object.properties = new Specification.Basicpropsdef(object.properties);
     }
 
     if (properties.token) {
-      object.properties = new Specification.Bearerpropsdef(object);
+      object.properties = new Specification.Bearerpropsdef(object.properties);
     }
 
     if (properties.grantType) {
-      object.properties = new Specification.Oauth2propsdef(object);
+      object.properties = new Specification.Oauth2propsdef(object.properties);
     }
   }
 }


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:
Fixing a bug where the properties on Auth definitions are passed the Auth definition itself rather than the propertiers during instantiation causing an invalid structure.

**Special notes for reviewers**:

**Additional information (if needed):**