### PR TITLE
Add version 0.8.4 and typo warning for previous versions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,17 @@ With the SDK you can:
 
 ### Status
 
-| Latest Releases | Conformance to spec version |
+| Latest Releases | Conformance to Spec Version |
 | :---: | :---: |
+| [v0.8.4](https://github.com/serverlessworkflow/sdk-typescript/releases/) | [v0.8](https://github.com/serverlessworkflow/specification/tree/0.8.x) |
+
+> [!WARNING]
+> Previous versions of the SDK were published with a typo in the scope:
+> @severlessworkflow/sdk-typescript instead of
+> @se**r**verlessworkflow/sdk-typescript
+
+|                             Latest Releases                              | Conformance to spec version |
+|:------------------------------------------------------------------------:| :---: |
 | [v1.0.0](https://github.com/serverlessworkflow/sdk-typescript/releases/) | [v0.6](https://github.com/serverlessworkflow/specification/tree/0.6.x) |
 | [v2.0.0](https://github.com/serverlessworkflow/sdk-typescript/releases/) | [v0.7](https://github.com/serverlessworkflow/specification/tree/0.7.x) |
 | [v3.0.0](https://github.com/serverlessworkflow/sdk-typescript/releases/) | [v0.8](https://github.com/serverlessworkflow/specification/tree/0.8.x) |


### PR DESCRIPTION
This PR adds information about the new version 0.8.4 to README file.

Changes:
* The new version was added to the latest releases table.
* Package name typo was fixed in the v0.8.4, so a typo warning for previous versions was also included. 