### PR TITLE
chore: use tokenless publishing (oidc/trusted publisher)

### DIFF
--- a/.github/workflows/npmjs-release.yml
+++ b/.github/workflows/npmjs-release.yml
@@ -29,6 +29,4 @@ jobs:
       - run: npm test
       - run: npm run build
       - run: npm run validate:package:dist
-      - run: cd dist && npm publish --access=public --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
+      - run: cd dist && npm publish --access=public


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:
This pull request makes a minor update to the npm publish step in the `.github/workflows/npmjs-release.yml` workflow. The change removes the `--provenance` flag and the associated `NODE_AUTH_TOKEN` environment variable from the `npm publish` command.

**Special notes for reviewers**:

**Additional information (if needed):**
It should be aligned with [npm's doc](https://docs.npmjs.com/trusted-publishers?utm_source=chatgpt.com#step-2-configure-your-cicd-workflow)