### PR TITLE
ci: disable codegen check until open-workflow-specification.org is online

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -30,6 +30,6 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run lint
-      - run: npm run codegen:check
+      # - run: npm run codegen:check # disabled until open-workflow-specification.org domain is online
       - run: npm test
       - run: npm run validate:package


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:
This pull request makes a small change to the Node CI workflow by commenting out the `codegen:check` step. This step has been temporarily disabled until the `open-workflow-specification.org` domain is online.

**Special notes for reviewers**:

**Additional information (if needed):**
