### PR TITLE
fix: accept dsl versions with pre-release tags for minimum in range

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openworkflowspec/sdk",
-  "version": "1.0.3-alpha5",
+  "version": "1.0.3-alpha6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openworkflowspec/sdk",
-      "version": "1.0.3-alpha5",
+      "version": "1.0.3-alpha6",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.20.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openworkflowspec/sdk",
-  "version": "1.0.3-alpha5",
+  "version": "1.0.3-alpha6",
   "schemaVersion": "1.0.3",
   "supportedDslVersions": ">=1.0.0-0 <=1.0.3",
   "description": "Typescript SDK for Open Workflow Specification",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@openworkflowspec/sdk",
   "version": "1.0.3-alpha5",
   "schemaVersion": "1.0.3",
-  "supportedDslVersions": ">=1.0.0 <=1.0.3",
+  "supportedDslVersions": ">=1.0.0-0 <=1.0.3",
   "description": "Typescript SDK for Open Workflow Specification",
   "type": "commonjs",
   "main": "./index.cjs",

--- a/tests/validation/workflow-validation.spec.ts
+++ b/tests/validation/workflow-validation.spec.ts
@@ -124,7 +124,7 @@ describe('Workflow validation', () => {
     expect(result).not.toThrow(Error);
   });
 
-  it('should be valid with a pre-release version within the supported range', () => {
+  it('should be valid with a pre-release version within the supported range (maximum)', () => {
     const preReleaseVersion = `${schemaVersion}-alpha`;
     const workflow = new Classes.Workflow({
       document: {
@@ -148,19 +148,28 @@ describe('Workflow validation', () => {
     expect(result).not.toThrow(Error);
   });
 
-  it('should throw with a pre-release version below the minimum supported', () => {
-    const preReleaseVersion = '1.0.0-alpha';
+  it('should be valid with a version within the supported range (minimum)', () => {
+    const version = '1.0.0-alpha';
     const workflow = new Classes.Workflow({
       document: {
-        dsl: preReleaseVersion,
+        dsl: version,
         name: 'test',
         version: '1.0.0',
         namespace: 'default',
       },
+      do: [
+        {
+          step1: {
+            set: {
+              foo: 'bar',
+            },
+          },
+        },
+      ],
     });
-    expect(() => workflow.validate()).toThrow(
-      `The DSL version of the workflow '${preReleaseVersion}' does not satisfy the DSL version range supported by this SDK '${supportedDslVersions}'.`,
-    );
+
+    const result = () => validate('Workflow', workflow);
+    expect(result).not.toThrow(Error);
   });
 
   it('should throw with a pre-release version above the supported range', () => {


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

Fixes https://github.com/open-workflow-specification/sdk-typescript/issues/291

**What this PR does / why we need it**:
Fixes DSL version validation rejecting valid dsl versions. The valid range was 1.0.0 >=1.0.3 which meant valid versions like `1.0.0-alpha` were incorrectly rejected. The previous PR https://github.com/open-workflow-specification/sdk-typescript/pull/267 purposely rejected these but the rejection logic was incorrect as they should be considered valid

Updated supported range to `1.0.0-0 >=1.0.3` so those values are now accepted 

**Special notes for reviewers**:

**Additional information (if needed):**
