### PR TITLE
ci: re-enable codegen check

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -30,6 +30,6 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run lint
-      # - run: npm run codegen:check # disabled until open-workflow-specification.org domain is online
+      - run: npm run codegen:check
       - run: npm test
       - run: npm run validate:package


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:
open-workflow-specification.org domain is now online, re-enabling `codegen:check` step. Originally disabled here https://github.com/open-workflow-specification/sdk-typescript/pull/288

**Special notes for reviewers**:
- Ran:
```
   npm run codegen
   npm run codegen:check
   npm lint
   npm test
   npm run validate:package  
```
